### PR TITLE
Throw Descriptive Exceptions and Resolve OptiFine Resolution Issues

### DIFF
--- a/src/main/java/club/decencies/remapper/lunar/Main.java
+++ b/src/main/java/club/decencies/remapper/lunar/Main.java
@@ -381,6 +381,10 @@ public class Main {
                     }
                 }
             }
+            else {
+                throw new UnsupportedOperationException("Could not resolve the input's version, so no further operations are supported." +
+                        "\nDid you forget to add a blank file with the title of the version inside of the lunar-prod JAR?");
+            }
         });
     }
 

--- a/src/main/java/club/decencies/remapper/lunar/util/FileUtil.java
+++ b/src/main/java/club/decencies/remapper/lunar/util/FileUtil.java
@@ -1,6 +1,7 @@
 package club.decencies.remapper.lunar.util;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -14,7 +15,9 @@ import java.util.zip.ZipFile;
  */
 public class FileUtil {
 
-    public static void walk(File directory, BiConsumer<File, File> consumer) {
+    public static void walk(File directory, BiConsumer<File, File> consumer) throws FileNotFoundException {
+        assertDirectoryExists(directory);
+
         for (File child : Objects.requireNonNull(directory.listFiles())) {
             if (child.isDirectory()) {
                 for (File file : Objects.requireNonNull(child.listFiles())) {
@@ -38,7 +41,9 @@ public class FileUtil {
         ts.forEach(r -> processor.accept(r, global));
     }
 
-    public static Collection<File> walk(File directory, String filter) {
+    public static Collection<File> walk(File directory, String filter) throws FileNotFoundException {
+        assertDirectoryExists(directory);
+
         return walk(directory, filter, new ArrayList<>());
     }
 
@@ -51,4 +56,9 @@ public class FileUtil {
         return current;
     }
 
+    private static void assertDirectoryExists(File directory) throws FileNotFoundException {
+        if (!directory.exists()) {
+            throw new FileNotFoundException("The directory \"" + directory.getName() + "\" does not exist!");
+        }
+    }
 }

--- a/src/main/java/club/decencies/remapper/lunar/util/FileUtil.java
+++ b/src/main/java/club/decencies/remapper/lunar/util/FileUtil.java
@@ -58,7 +58,8 @@ public class FileUtil {
 
     private static void assertDirectoryExists(File directory) throws FileNotFoundException {
         if (!directory.exists()) {
-            throw new FileNotFoundException("The directory \"" + directory.getName() + "\" does not exist!");
+            throw new FileNotFoundException("The directory \"" + directory.getName() + "\" does not exist!" +
+                    " The full expected path: " + directory.getAbsolutePath());
         }
     }
 }

--- a/src/main/java/club/decencies/remapper/lunar/util/OptiFineDownloader.java
+++ b/src/main/java/club/decencies/remapper/lunar/util/OptiFineDownloader.java
@@ -19,7 +19,7 @@ public class OptiFineDownloader {
     // todo refactor..
     @SneakyThrows
     public static void download(String version, File destination, Consumer<JarFile> consumer) {
-        if (!version.startsWith("preview") && version.contains("pre")) {
+        if (!version.contains("preview_") && version.contains("pre")) {
             version = "preview_".concat(version);
         }
         if (destination.exists() && destination.length() > 0) {


### PR DESCRIPTION
This pull request makes a couple changes:
* Preview OptiFine versions are now able to be automatically downloaded.
* Descriptive exceptions are thrown in some cases.
  * When a directory is unresolved, the program throws an appropriate exception and tells the user which directory was missing.
  * If the Lunar version was not set, an exception is thrown reminding them to add a blank file with the version as its name in their production `.jar` file.